### PR TITLE
Alerta con calificación del examen y fecha en la tabla de los resultados anteriores

### DIFF
--- a/Learn-to-py/Base.lproj/Main.storyboard
+++ b/Learn-to-py/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina4_7" orientation="landscape" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -380,7 +380,7 @@ Desarrollada como proyecto final para la clase de Proyecto para Dispositivos Mó
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="cell" id="T3H-co-I1S">
-                                        <rect key="frame" x="0.0" y="24.5" width="468" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="28" width="468" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="T3H-co-I1S" id="7uK-n1-MKr">
                                             <rect key="frame" x="0.0" y="0.0" width="468" height="43.5"/>

--- a/Learn-to-py/ExamResult.swift
+++ b/Learn-to-py/ExamResult.swift
@@ -11,6 +11,7 @@ class ExamResult: NSObject, Codable {
     var questions: Double!
     var correctAnswers: Double!
     var grade: Double! { (correctAnswers / questions) * 100 }
+    var date: Date!
 
     init(questions: Double!) {
         self.questions = questions

--- a/Learn-to-py/ExamViewController.swift
+++ b/Learn-to-py/ExamViewController.swift
@@ -45,8 +45,14 @@ class ExamViewController: UIViewController {
             
             question += 1
             if question == questions.count {
-                registerResults()
-                exit(sender)
+                result.date = Date()
+                let alerta = UIAlertController(title: "Resultados", message: "Su calificación en este examen es de \(result.grade!)", preferredStyle: .alert)
+                let accion = UIAlertAction(title: "Entendido", style: .cancel, handler: { action in
+                    self.registerResults()
+                    self.exit(sender)
+                })
+                alerta.addAction(accion)
+                present(alerta, animated: true, completion: nil)
             } else {
                 questionLabel.text = questions[question].content
                 image.image = questions[question].image

--- a/Learn-to-py/ResultsViewController.swift
+++ b/Learn-to-py/ResultsViewController.swift
@@ -27,7 +27,7 @@ class ResultsViewController: UIViewController, UITableViewDelegate, UITableViewD
         let cell = tableView.dequeueReusableCell(withIdentifier: "cell")!
         let result = results[indexPath.row]
         
-        cell.textLabel?.text = "\(result.correctAnswers!) de \(result.questions!) correctas: \(result.grade!)%"
+        cell.textLabel?.text = "\(result.correctAnswers!) de \(result.questions!) correctas: \(result.grade!). Fecha de presentación: \(result.date!)"
         
         return cell
     }


### PR DESCRIPTION
Se agregó una alerta en la vista del examen para que el usuario pueda ver la calificación que sacó y se regresa a la vista anterior al presionar el botón de confirmación. También se trató de agregar la impresión de la fecha en la tabla de los resultados, pero hubo un error al momento de desenvolver la variable porque tiene un valor nulo y no se supo cómo corregirlo