### PR TITLE
Fix keyboard popup resetting position and invalid step

### DIFF
--- a/Learn-to-py/EditIterable.swift
+++ b/Learn-to-py/EditIterable.swift
@@ -37,7 +37,13 @@ class EditIterable: KeyboardViewPushController, UITextFieldDelegate {
     }
     
     @IBAction func onExit(_ sender: UITapGestureRecognizer) {
-        if let name = name.text, let content = content.text {
+        var shouldRefresh = false
+        if let name = name.text {
+            delegate.updateIterable(name: name)
+            shouldRefresh = true
+        }
+        
+        if let content = content.text {
             var array = content.components(separatedBy: " ").compactMap({ Int($0) })
             var displayFormat = "[\(array.map{String($0)}.joined(separator: ", "))]"
             
@@ -55,14 +61,29 @@ class EditIterable: KeyboardViewPushController, UITextFieldDelegate {
                     step = array[2]
                 }
                 
-                displayFormat = "range(\(min), \(max), \(step))"
-                array = Array(stride(from: min, to: max, by: step))
+                if step != 0 {
+                    displayFormat = "range(\(min), \(max), \(step))"
+                    array = Array(stride(from: min, to: max, by: step))
+                } else {
+                    array = []
+                }
             }
             
             if array.count > 0 {
-                delegate.update(name: name, type: type.selectedSegmentIndex, displayFormat: displayFormat, content: array)
-                dismiss(animated: true, completion: nil)
+                delegate.update(type: type.selectedSegmentIndex, displayFormat: displayFormat, content: array)
+                shouldRefresh = true
+            } else if content.count > 0 {
+                let alerta = UIAlertController(title: "Error!", message: "Por favor ingrese un iterable válido", preferredStyle: .alert)
+                let accion = UIAlertAction(title: "Entendido", style: .cancel, handler: nil)
+                alerta.addAction(accion)
+                present(alerta, animated: true, completion: nil)
+                shouldRefresh = false
             }
+        }
+        
+        if shouldRefresh {
+            dismiss(animated: true, completion: nil)
+            delegate.refresh()
         }
     }
     

--- a/Learn-to-py/EditVariable.swift
+++ b/Learn-to-py/EditVariable.swift
@@ -27,7 +27,7 @@ class EditVariable: KeyboardViewPushController, UITextFieldDelegate {
 
     @IBAction func onExit(_ sender: UITapGestureRecognizer) {
         if let name = name.text {
-            delegate.update(name: name)
+            delegate.updateIterator(name: name)
             dismiss(animated: true, completion: nil)
         }
     }

--- a/Learn-to-py/KeyboardViewPushController.swift
+++ b/Learn-to-py/KeyboardViewPushController.swift
@@ -13,12 +13,14 @@ class KeyboardViewPushController: UIViewController {
         super.viewDidLoad()
 
         NotificationCenter.default.addObserver(self, selector: #selector(self.keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(self.keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.keyboardWillHide), name: UIResponder.keyboardDidHideNotification, object: nil)
     }
     
     @objc func keyboardWillShow(notification: Notification) {
         if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
-            moveView(offset: getMoveAmount(keyboardSize: keyboardSize))
+            if self.view.frame.origin.y == 0 {
+                moveView(offset: getMoveAmount(keyboardSize: keyboardSize))
+            }
         }
     }
     

--- a/Learn-to-py/ViewControllerLoop.swift
+++ b/Learn-to-py/ViewControllerLoop.swift
@@ -8,9 +8,11 @@
 import UIKit
 
 protocol AutoUpdate {
-    func update(name: String) // Variable update
+    func updateIterator(name: String) // Variable update
+    func updateIterable(name: String) // Variable update
     func update(snippet: CodeSnippet) // Snippet update
-    func update(name: String, type: Int, displayFormat: String, content: Array<Int>) // Iterable update
+    func update(type: Int, displayFormat: String, content: Array<Int>) // Iterable update
+    func refresh()
 }
 
 class ViewControllerLoop: UIViewController, AutoUpdate {
@@ -157,11 +159,15 @@ class ViewControllerLoop: UIViewController, AutoUpdate {
     }
     
     // MARK: - AutoUpdate
-    func update(name: String) {
+    func updateIterator(name: String) {
         iterator.name = name
         iterator.value = 0
         
         refresh()
+    }
+    
+    func updateIterable(name: String) {
+        iterable.name = name
     }
     
     func update(snippet: CodeSnippet) {
@@ -170,13 +176,10 @@ class ViewControllerLoop: UIViewController, AutoUpdate {
         refresh()
     }
     
-    func update(name: String, type: Int, displayFormat: String, content: Array<Int>) {
-        iterable.name = name
+    func update(type: Int, displayFormat: String, content: Array<Int>) {
         iterable.value = content
         iterableDisplayFormat = displayFormat
         iterableType = type
-        
-        refresh()
     }
     
     // MARK: - Navigation


### PR DESCRIPTION
* [fix] The position of the view was reset if you double tapped the keyboard
* [enhancement] You can now exit out of the change iterable popup without requiring changes
* [fix] Step 0 would cause the application to crash
* [enhancement] Display a popup if you enter an invalid range rather than not doin anything
* [change] You can now update the name and value separately for editing iterable